### PR TITLE
Altered the inspect signature for python 2 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,6 @@ ENV/
 
 # Rope project settings
 .ropeproject
+
+# PyCharm
+.idea/

--- a/bottlejwt.py
+++ b/bottlejwt.py
@@ -60,7 +60,8 @@ class JwtPlugin(object):
         def wrapper(*args, **kwargs):
             auth = self.get_auth()
             if self.validation(auth, auth_value):
-                if inspect.signature(callback).parameters.get(self.keyword):
+                sig = inspect.getargspec(callback)
+                if self.keyword in sig.args:
                     kwargs[self.keyword] = auth
                 return callback(*args, **kwargs)
             else:


### PR DESCRIPTION
Hi,

I noticed the wrapper uses the inspect.signature function which is only supported in Python 3.
I have updated it to use the inspect.getargspec function which is supported in both Python 3 and 2.

Enzo